### PR TITLE
fixed duplication of test_save_refresh

### DIFF
--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -25,11 +25,11 @@ class TestAnnotation(TestCase):
 
     def test_save_refresh(self):
         a = Annotation(name='bob')
-        c = pa.es.conn
+        c = a.es.conn
         a.save(refresh=True)
         assert_true('id' in a)
 
-    def test_save_refresh(self):
+    def test_save_assert_refresh(self):
         a = Annotation(name='bob')
         a.es = MagicMock()
         a.es.index = 'foo'


### PR DESCRIPTION
I noticed that TestAnnotation.test_save_refresh was defined twice and the first definition had a small bug in it.
