### PR TITLE
Changing the index of the 'tags' field to not_analyzed.

### DIFF
--- a/annotator/annotation.py
+++ b/annotator/annotation.py
@@ -8,7 +8,7 @@ MAPPING = {
     'created': {'type': 'date'},
     'updated': {'type': 'date'},
     'quote': {'type': 'string'},
-    'tags': {'type': 'string', 'index_name': 'tag'},
+    'tags': {'type': 'string', 'index': 'not_analyzed'},
     'text': {'type': 'string'},
     'uri': {'type': 'string', 'index': 'not_analyzed'},
     'user': {'type': 'string', 'index': 'not_analyzed'},


### PR DESCRIPTION
Before that (as discussed in the dev list) the tag field was analyzed with the
default analyzer which prevented searching for a set of stopwords
(i.e. 'a', 'the', 'as', etc.) But we do not want to limit
the name of the tags, and for a first approach no further tokenization
is needed.
