### PR TITLE
Pluggable Annotation class

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,7 @@ from .helpers import MockUser, MockConsumer
 
 here = os.path.dirname(__file__)
 
+
 def create_app():
     app = Flask(__name__)
     app.config.from_pyfile(os.path.join(here, 'test.cfg'))

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -3,10 +3,11 @@ from .helpers import MockUser
 from nose.tools import *
 from mock import patch
 
-from flask import json
+from flask import json, g
 
 from annotator import auth, es
 from annotator.annotation import Annotation
+
 
 class TestStore(TestCase):
     def setup(self):
@@ -51,6 +52,12 @@ class TestStore(TestCase):
 
         assert headers['Access-Control-Expose-Headers'] == 'Content-Length, Content-Type, Location', \
             "Did not send the right Access-Control-Expose-Headers header."
+
+    @patch('annotator.store.Annotation')
+    def test_pluggable_class(self, ann_mock):
+        g.annotation_class = ann_mock
+        response = self.cli.get('/api/annotations/testID', headers=self.headers)
+        ann_mock.return_value.fetch.assert_called_once()
 
     def test_index(self):
         response = self.cli.get('/api/annotations', headers=self.headers)


### PR DESCRIPTION
We're already using the Flask.g to store thread local variables, hooks, and the Annotation class itself can be a session variable too.

That way the class itself is pluggable so custom implementation can be used within our framework.
If no custom implementation is set, we set the default Annotation class.

Added a test case for it too.

The two additional +1 blank line inserts are for PEP8
