### PR TITLE
Don't pass kwargs everywhere, but do keep params to Elasticsearch.search separated

### DIFF
--- a/annotator/annotation.py
+++ b/annotator/annotation.py
@@ -65,18 +65,18 @@ class Annotation(es.Model):
         super(Annotation, self).save(*args, **kwargs)
 
     @classmethod
-    def search_raw(cls, query=None, user=None, authorization_enabled=None,
-                   **kwargs):
+    def search_raw(cls, query=None, params=None, raw_result=False,
+                   user=None, authorization_enabled=None):
         """Perform a raw Elasticsearch query
 
         Any ElasticsearchExceptions are to be caught by the caller.
 
         Keyword arguments:
         query -- Query to send to Elasticsearch
+        params -- Extra keyword arguments to pass to Elasticsearch.search
+        raw_result -- Return Elasticsearch's response as is
         user -- The user to filter the results for according to permissions
         authorization_enabled -- Overrides Annotation.es.authorization_enabled
-        raw_result -- Return Elasticsearch's response as is
-        Extra keyword arguments are passed to Elasticsearch.search
         """
         if query is None:
             query = {}
@@ -97,7 +97,8 @@ class Annotation(es.Model):
             # Use the filtered query instead of the original
             query['query'] = filtered_query
 
-        res = super(Annotation, cls).search_raw(query=query, **kwargs)
+        res = super(Annotation, cls).search_raw(query=query, params=params,
+                                                raw_result=raw_result)
         return res
 
     @classmethod

--- a/annotator/store.py
+++ b/annotator/store.py
@@ -292,16 +292,19 @@ def search_annotations():
 def search_annotations_raw():
 
     try:
-        query, kwargs = _build_query_raw(request)
+        query, params = _build_query_raw(request)
     except ValueError:
         return jsonify('Could not parse request payload!',
                        status=400)
 
     if current_app.config.get('AUTHZ_ON'):
-        kwargs['user'] = g.user
+        user = g.user
+    else:
+        user = None
 
     try:
-        res = g.annotation_class.search_raw(query, raw_result=True, **kwargs)
+        res = g.annotation_class.search_raw(query, params, raw_result=True,
+                                            user=user)
     except TransportError as err:
         if err.status_code is not 'N/A':
             status_code = err.status_code


### PR DESCRIPTION
A combination of #91 and #101. As suggested in https://github.com/openannotation/annotator-store/pull/101#issuecomment-57284831
