### PR TITLE
110 multiple document equivalences

### DIFF
--- a/annotator/annotation.py
+++ b/annotator/annotation.py
@@ -49,8 +49,8 @@ class Annotation(es.Model):
         # If we do then we'll merge the supplied links into it.
 
         if 'document' in self:
-            d = self['document']
-            document.Document.save_document_data(d)
+            d = document.Document(self['document'])
+            d.save()
 
         super(Annotation, self).save(*args, **kwargs)
 

--- a/annotator/annotation.py
+++ b/annotator/annotation.py
@@ -50,17 +50,7 @@ class Annotation(es.Model):
 
         if 'document' in self:
             d = self['document']
-            uris = [link['href'] for link in d['link']]
-            docs = document.Document.get_all_by_uris(uris)
-
-            if len(docs) == 0:
-                doc = document.Document(d)
-                doc.save()
-            else:
-                doc = docs[0]
-                links = d.get('link', [])
-                doc.merge_links(links)
-                doc.save()
+            document.Document.save_document_data(d)
 
         super(Annotation, self).save(*args, **kwargs)
 

--- a/annotator/document.py
+++ b/annotator/document.py
@@ -110,9 +110,17 @@ class Document(es.Model):
 
         return documents
 
+    def _remove_deficient_links(self):
+        # Remove links without a type or href
+        links = self.get('link', [])
+        filtered_list = [l for l in links if 'type' in l and 'href' in l]
+        self['link'] = filtered_list
+
     def save(self):
         """Saves document metadata, looks for existing documents and
         merges them to maintain equivalence classes"""
+        self._remove_deficient_links()
+
         uris = self.uris()
 
         # Get existing documents

--- a/annotator/document.py
+++ b/annotator/document.py
@@ -24,6 +24,7 @@ MAPPING = {
         }
     }
 }
+MAX_ITERATIONS = 5
 
 
 class Document(es.Model):
@@ -93,8 +94,9 @@ class Document(es.Model):
         documents = {}
         all_uris = set(uris)
         new_uris = list(uris)
+        iterations = 0
 
-        while len(new_uris):
+        while len(new_uris) and iterations < MAX_ITERATIONS:
             docs = cls._get_all_by_uris(new_uris)
             new_uris = []
             for doc in docs:
@@ -105,6 +107,7 @@ class Document(es.Model):
                         if uri not in all_uris:
                             new_uris.append(uri)
                             all_uris.add(uri)
+            iterations += 1
 
         return list(documents.values())
 

--- a/annotator/document.py
+++ b/annotator/document.py
@@ -33,11 +33,11 @@ class Document(es.Model):
     @classmethod
     def get_by_uri(cls, uri):
         """Returns the first document match for a given URI."""
-        results = cls.get_all_by_uris([uri])
+        results = cls._get_all_by_uris([uri])
         return results[0] if len(results) > 0 else []
 
     @classmethod
-    def get_all_by_uris(cls, uris):
+    def _get_all_by_uris(cls, uris):
         """
         Returns a list of documents that have any of the supplied URIs.
 
@@ -95,7 +95,7 @@ class Document(es.Model):
         new_uris = list(uris)
 
         while len(new_uris):
-            docs = cls.get_all_by_uris(new_uris)
+            docs = cls._get_all_by_uris(new_uris)
             new_uris = []
             for doc in docs:
                 if doc['id'] not in documents:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -272,7 +272,6 @@ class TestDocument(TestCase):
         d3 = Document.fetch(3)
         assert d3 is None
 
-
         d4 = Document({
             "id": "4",
             "title": "document4",
@@ -296,6 +295,7 @@ class TestDocument(TestCase):
         })
 
         d5.save()
+
         # The documents have been merged
         d1 = Document.fetch(1)
         d2 = Document.fetch(2)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -60,6 +60,28 @@ class TestDocument(TestCase):
         assert d['updated']
 
     @staticmethod
+    def test_deficient_links():
+        d = Document({
+            "id": "1",
+            "title": "Chaos monkey: The messed up links",
+            "link": [{
+                "href": "http://cuckoo.baboon/"
+            }, {
+                # I'm an empty link entry
+            }, {
+                "type": "text/html"
+            }, {
+                "href": "http://cuckoo.baboon/",
+                "type": "text/html"
+            }]
+        })
+        d.save()
+        d = Document.fetch("1")
+        assert_equal(len(d['link']), 1)
+        assert_equal(d['link'][0]['href'], "http://cuckoo.baboon/")
+        assert_equal(d['link'][0]['type'], "text/html")
+
+    @staticmethod
     def test_delete():
         ann = Document(id=1)
         ann.save()

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -212,10 +212,10 @@ class TestDocument(TestCase):
         d2 = Document.fetch(2)
         d3 = Document.fetch(3)
         d4 = Document.fetch(4)
-        assert d1
+        assert d1 is None
         assert d2 is None
         assert d3 is None
-        assert d4 is None
+        assert d4
 
     @staticmethod
     def test_save_merge_documents():
@@ -233,7 +233,7 @@ class TestDocument(TestCase):
         })
         d2.save()
 
-        # They are not merged yes
+        # They are not merged yet
         d1 = Document.fetch(1)
         d2 = Document.fetch(2)
         assert d1
@@ -246,8 +246,11 @@ class TestDocument(TestCase):
         })
         d3.save()
 
+        # d2 is merged into d3
+        d2 = Document.fetch(2)
         d3 = Document.fetch(3)
-        assert d3 is None
+        assert d2 is None
+        assert d3
 
         d4 = Document({
             "id": "4",
@@ -263,8 +266,8 @@ class TestDocument(TestCase):
         # A new document is created for d4
         # It is not merged
         d4.save()
-        count = Document.count()
-        assert count == 3
+        d4 = Document.fetch(4)
+        assert d4
 
         d5 = Document({
             "id": "5",
@@ -274,7 +277,7 @@ class TestDocument(TestCase):
 
         d5.save()
 
-        # The documents have been merged into d2
+        # The documents have been merged into d5
         d1 = Document.fetch(1)
         d2 = Document.fetch(2)
         d3 = Document.fetch(3)
@@ -282,7 +285,7 @@ class TestDocument(TestCase):
         d5 = Document.fetch(5)
 
         assert d1 is None
-        assert d2
+        assert d2 is None
         assert d3 is None
         assert d4
-        assert d5 is None
+        assert d5

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -43,6 +43,7 @@ class TestDocument(TestCase):
 
     @staticmethod
     def test_basics():
+        # Creating a single document and verifies the saved attributes
         d = Document({
             "id": "1",
             "title": "Annotations: The Missing Manual",
@@ -61,6 +62,7 @@ class TestDocument(TestCase):
 
     @staticmethod
     def test_deficient_links():
+        # Test that bad links are not saved
         d = Document({
             "id": "1",
             "title": "Chaos monkey: The messed up links",
@@ -83,6 +85,7 @@ class TestDocument(TestCase):
 
     @staticmethod
     def test_delete():
+        # Test deleting a document
         ann = Document(id=1)
         ann.save()
 
@@ -94,6 +97,7 @@ class TestDocument(TestCase):
 
     @staticmethod
     def test_search():
+        # Test search retrieve
         d = Document({
             "id": "1",
             "title": "document",
@@ -105,8 +109,7 @@ class TestDocument(TestCase):
 
     @staticmethod
     def test_get_by_uri():
-
-        # create 3 documents and make sure get_by_uri works properly
+        # Make sure that only the document with the given uri is retrieved
 
         d = Document({
             "id": "1",
@@ -118,13 +121,6 @@ class TestDocument(TestCase):
         d = Document({
             "id": "2",
             "title": "document2",
-            "link": [peerj["html"], peerj["pdf"]]
-        })
-        d.save()
-
-        d = Document({
-            "id": "3",
-            "title": "document3",
             "link": [
                 {
                     "href": "http://nature.com/123/",
@@ -134,30 +130,16 @@ class TestDocument(TestCase):
         })
         d.save()
 
+        d = Document({
+            "id": "3",
+            "title": "document3",
+            "link": [peerj["doc"]]
+        })
+        d.save()
+
         doc = Document.get_by_uri("https://peerj.com/articles/53/")
         assert doc
         assert_equal(doc['title'], "document1") 
-
-    @staticmethod
-    def test_get_all_by_uri():
-        # add two documents and make sure we can search for both
-
-        d = Document({
-            "id": "1",
-            "title": "document1",
-            "link": [peerj["html"]]
-        })
-        d.save()
-
-        d = Document({
-            "id": "2",
-            "title": "document2",
-            "link": [peerj["pdf"]]
-        })
-        d.save()
-
-        docs = Document._get_all_by_uris(["https://peerj.com/articles/53/", "https://peerj.com/articles/53.pdf"])
-        assert_equal(len(docs), 2)
 
     @staticmethod
     def test_uris():
@@ -226,10 +208,6 @@ class TestDocument(TestCase):
         })
         d4.save()
 
-        uris = ["https://peerj.com/articles/53/"]
-        docs = Document._get_all_iterative_for_uris(uris)
-        assert len(docs) == 1
-
         d1 = Document.fetch(1)
         d2 = Document.fetch(2)
         d3 = Document.fetch(3)
@@ -238,7 +216,6 @@ class TestDocument(TestCase):
         assert d2 is None
         assert d3 is None
         assert d4 is None
-
 
     @staticmethod
     def test_save_merge_documents():
@@ -283,7 +260,8 @@ class TestDocument(TestCase):
             ]
         })
 
-        # # A new document is created for this
+        # A new document is created for d4
+        # It is not merged
         d4.save()
         count = Document.count()
         assert count == 3
@@ -296,7 +274,7 @@ class TestDocument(TestCase):
 
         d5.save()
 
-        # The documents have been merged
+        # The documents have been merged into d2
         d1 = Document.fetch(1)
         d2 = Document.fetch(2)
         d3 = Document.fetch(3)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -156,7 +156,7 @@ class TestDocument(TestCase):
         })
         d.save()
 
-        docs = Document.get_all_by_uris(["https://peerj.com/articles/53/", "https://peerj.com/articles/53.pdf"])
+        docs = Document._get_all_by_uris(["https://peerj.com/articles/53/", "https://peerj.com/articles/53.pdf"])
         assert_equal(len(docs), 2)
 
     @staticmethod

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -5,8 +5,27 @@ from . import TestCase
 from annotator.document import Document
 
 
-class TestDocument(TestCase):
+peerj = {
+    "html": {
+        "href": "https://peerj.com/articles/53/",
+        "type": "text/html"
+    },
+    "pdf": {
+        "href": "https://peerj.com/articles/53.pdf",
+        "type": "application/pdf"
+    },
+    "doc": {
+        "href": "http://peerj.com/articles/53.doc",
+        "type": "application/vnd.ms-word.document"
+    },
+    "docx": {
+        "href": "https://peerj.com/articles/53.docx",
+        "type": "application/vnd.ms-word.document"
+    }
+}
 
+
+class TestDocument(TestCase):
     def setup(self):
         super(TestDocument, self).setup()
         self.ctx = self.app.test_request_context(path='/api')
@@ -27,16 +46,7 @@ class TestDocument(TestCase):
         d = Document({
             "id": "1",
             "title": "Annotations: The Missing Manual",
-            "link": [
-                {
-                    "href": "https://peerj.com/articles/53/",
-                    "type": "text/html"
-                },
-                {
-                    "href": "https://peerj.com/articles/53.pdf",
-                    "type": "application/pdf"
-                }
-            ],
+            "link": [peerj["html"], peerj["pdf"]]
         })
         d.save()
         d = Document.fetch("1")
@@ -65,16 +75,7 @@ class TestDocument(TestCase):
         d = Document({
             "id": "1",
             "title": "document",
-            "link": [
-                {
-                    "href": "https://peerj.com/articles/53/",
-                    "type": "text/html"
-                },
-                {
-                    "href": "https://peerj.com/articles/53.pdf",
-                    "type": "application/pdf"
-                }
-            ],
+            "link": [peerj["html"], peerj["pdf"]]
         })
         d.save()
         res = Document.search(query={'title': 'document'})
@@ -88,32 +89,14 @@ class TestDocument(TestCase):
         d = Document({
             "id": "1",
             "title": "document1",
-            "link": [
-                {
-                    "href": "https://peerj.com/articles/53/",
-                    "type": "text/html"
-                },
-                {
-                    "href": "https://peerj.com/articles/53.pdf",
-                    "type": "application/pdf"
-                },
-            ],
+            "link": [peerj["html"], peerj["pdf"]]
         })
         d.save()
 
         d = Document({
             "id": "2",
             "title": "document2",
-            "link": [
-                {
-                    "href": "https://peerj.com/articles/53/",
-                    "type": "text/html"
-                },
-                {
-                    "href": "https://peerj.com/articles/53.pdf",
-                    "type": "application/pdf"
-                },
-            ],
+            "link": [peerj["html"], peerj["pdf"]]
         })
         d.save()
 
@@ -140,24 +123,14 @@ class TestDocument(TestCase):
         d = Document({
             "id": "1",
             "title": "document1",
-            "link": [
-                {
-                    "href": "https://peerj.com/articles/53/",
-                    "type": "text/html"
-                },
-            ]
+            "link": [peerj["html"]]
         })
         d.save()
 
         d = Document({
             "id": "2",
             "title": "document2",
-            "link": [
-                {
-                    "href": "https://peerj.com/articles/53.pdf",
-                    "type": "application/pdf"
-                }
-            ]
+            "link": [peerj["pdf"]]
         })
         d.save()
 
@@ -169,16 +142,7 @@ class TestDocument(TestCase):
         d = Document({
             "id": "1",
             "title": "document",
-            "link": [
-                {
-                    "href": "https://peerj.com/articles/53/",
-                    "type": "text/html"
-                },
-                {
-                    "href": "https://peerj.com/articles/53.pdf",
-                    "type": "application/pdf"
-                }
-            ],
+            "link": [peerj["html"], peerj["pdf"]]
         })
         assert_equal(d.uris(), [
             "https://peerj.com/articles/53/",
@@ -190,16 +154,7 @@ class TestDocument(TestCase):
         d = Document({
             "id": "1",
             "title": "document",
-            "link": [
-                {
-                    "href": "https://peerj.com/articles/53/",
-                    "type": "text/html"
-                },
-                {
-                    "href": "https://peerj.com/articles/53.pdf",
-                    "type": "application/pdf"
-                }
-            ],
+            "link": [peerj["html"], peerj["pdf"]]
         })
         d.save()
 
@@ -207,16 +162,7 @@ class TestDocument(TestCase):
         assert d
         assert_equal(len(d['link']), 2)
 
-        d.merge_links([
-            {
-                "href": "https://peerj.com/articles/53/",
-                "type": "text/html"
-            },
-            {
-                "href": "http://peerj.com/articles/53.doc",
-                "type": "application/vnd.ms-word.document"
-            }
-        ])
+        d.merge_links([peerj["html"], peerj["doc"]])
         d.save()
 
         assert_equal(len(d['link']), 3)
@@ -228,4 +174,89 @@ class TestDocument(TestCase):
         assert doc
         assert_equal(len(doc['link']), 3)
 
+    @staticmethod
+    def test_get_all_recursive_for_uris():
+        d1 = Document({
+            "id": "1",
+            "title": "document1",
+            "link": [peerj["html"], peerj["pdf"]]
+        })
+        d1.save()
 
+        d2 = Document({
+            "id": "2",
+            "title": "document2",
+            "link": [peerj["pdf"], peerj["doc"]]
+        })
+        d2.save()
+
+        d3 = Document({
+            "id": "3",
+            "title": "document3",
+            "link": [peerj["doc"], peerj["docx"]]
+        })
+        d3.save()
+
+        d4 = Document({
+            "id": "4",
+            "title": "document4",
+            "link": [peerj["docx"]]
+        })
+        d4.save()
+
+        uris = ["https://peerj.com/articles/53/"]
+        docs = Document.get_all_recursive_for_uris(uris)
+        assert len(docs) == 4
+
+    @staticmethod
+    def test_merge_documents():
+        d1 = Document({
+            "id": "1",
+            "title": "document1",
+            "link": [peerj["html"], peerj["pdf"]]
+        })
+        d1.save()
+
+        d2 = Document({
+            "id": "2",
+            "title": "document2",
+            "link": [peerj["doc"], peerj["docx"]]
+        })
+        d2.save()
+
+        d3 = Document({
+            "id": "3",
+            "title": "document3",
+            "link": [peerj["doc"], peerj["docx"]]
+        })
+        d3.save()
+
+        document = {
+            "link": [
+                {
+                    "href": "https://totallydifferenturl.com",
+                    "type": "text/html"
+                }
+            ]
+        }
+
+        # A new document is created for this
+        Document.save_document_data(document)
+        count = Document.count()
+        assert count == 4
+
+        document = {
+            "link": [peerj["pdf"], peerj["doc"]]
+        }
+
+        Document.save_document_data(document)
+        # The unnecessary documents have been deleted
+        d1 = Document.fetch(1)
+        d2 = Document.fetch(2)
+        d3 = Document.fetch(3)
+        assert d1 is None
+        assert d2 is None
+        assert d3
+
+        uris = d3.uris()
+        assert len(uris) == 4

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -36,13 +36,11 @@ class TestDocument(TestCase):
         self.ctx.pop()
         super(TestDocument, self).teardown()
 
-    @staticmethod
-    def test_new():
+    def test_new(self):
         d = Document()
         assert_equal('{}', repr(d))
 
-    @staticmethod
-    def test_basics():
+    def test_basics(self):
         # Creating a single document and verifies the saved attributes
         d = Document({
             "id": "1",
@@ -60,8 +58,7 @@ class TestDocument(TestCase):
         assert d['created']
         assert d['updated']
 
-    @staticmethod
-    def test_deficient_links():
+    def test_deficient_links(self):
         # Test that bad links are not saved
         d = Document({
             "id": "1",
@@ -83,8 +80,7 @@ class TestDocument(TestCase):
         assert_equal(d['link'][0]['href'], "http://cuckoo.baboon/")
         assert_equal(d['link'][0]['type'], "text/html")
 
-    @staticmethod
-    def test_delete():
+    def test_delete(self):
         # Test deleting a document
         ann = Document(id=1)
         ann.save()
@@ -95,8 +91,7 @@ class TestDocument(TestCase):
         nodoc = Document.fetch(1)
         assert nodoc is None
 
-    @staticmethod
-    def test_search():
+    def test_search(self):
         # Test search retrieve
         d = Document({
             "id": "1",
@@ -107,8 +102,7 @@ class TestDocument(TestCase):
         res = Document.search(query={'title': 'document'})
         assert_equal(len(res), 1)
 
-    @staticmethod
-    def test_get_by_uri():
+    def test_get_by_uri(self):
         # Make sure that only the document with the given uri is retrieved
 
         d = Document({
@@ -141,8 +135,7 @@ class TestDocument(TestCase):
         assert doc
         assert_equal(doc['title'], "document1") 
 
-    @staticmethod
-    def test_uris():
+    def test_uris(self):
         d = Document({
             "id": "1",
             "title": "document",
@@ -153,8 +146,7 @@ class TestDocument(TestCase):
             "https://peerj.com/articles/53.pdf"
         ])
 
-    @staticmethod
-    def test_merge_links():
+    def test_merge_links(self):
         d = Document({
             "id": "1",
             "title": "document",
@@ -178,8 +170,7 @@ class TestDocument(TestCase):
         assert doc
         assert_equal(len(doc['link']), 3)
 
-    @staticmethod
-    def test_save():
+    def test_save(self):
         d1 = Document({
             "id": "1",
             "title": "document1",
@@ -217,8 +208,7 @@ class TestDocument(TestCase):
         assert d3 is None
         assert d4
 
-    @staticmethod
-    def test_save_merge_documents():
+    def test_save_merge_documents(self):
         d1 = Document({
             "id": "1",
             "title": "document1",

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -175,7 +175,7 @@ class TestDocument(TestCase):
         assert_equal(len(doc['link']), 3)
 
     @staticmethod
-    def test_get_all_recursive_for_uris():
+    def test_save():
         d1 = Document({
             "id": "1",
             "title": "document1",
@@ -205,11 +205,21 @@ class TestDocument(TestCase):
         d4.save()
 
         uris = ["https://peerj.com/articles/53/"]
-        docs = Document.get_all_recursive_for_uris(uris)
-        assert len(docs) == 4
+        docs = Document._get_all_iterative_for_uris(uris)
+        assert len(docs) == 1
+
+        d1 = Document.fetch(1)
+        d2 = Document.fetch(2)
+        d3 = Document.fetch(3)
+        d4 = Document.fetch(4)
+        assert d1
+        assert d2 is None
+        assert d3 is None
+        assert d4 is None
+
 
     @staticmethod
-    def test_merge_documents():
+    def test_save_merge_documents():
         d1 = Document({
             "id": "1",
             "title": "document1",
@@ -224,6 +234,12 @@ class TestDocument(TestCase):
         })
         d2.save()
 
+        # They are not merged yes
+        d1 = Document.fetch(1)
+        d2 = Document.fetch(2)
+        assert d1
+        assert d2
+
         d3 = Document({
             "id": "3",
             "title": "document3",
@@ -231,32 +247,42 @@ class TestDocument(TestCase):
         })
         d3.save()
 
-        document = {
+        d3 = Document.fetch(3)
+        assert d3 is None
+
+
+        d4 = Document({
+            "id": "4",
+            "title": "document4",
             "link": [
                 {
                     "href": "https://totallydifferenturl.com",
                     "type": "text/html"
                 }
             ]
-        }
+        })
 
-        # A new document is created for this
-        Document.save_document_data(document)
+        # # A new document is created for this
+        d4.save()
         count = Document.count()
-        assert count == 4
+        assert count == 3
 
-        document = {
+        d5 = Document({
+            "id": "5",
+            "title": "document5",
             "link": [peerj["pdf"], peerj["doc"]]
-        }
+        })
 
-        Document.save_document_data(document)
-        # The unnecessary documents have been deleted
+        d5.save()
+        # The documents have been merged
         d1 = Document.fetch(1)
         d2 = Document.fetch(2)
         d3 = Document.fetch(3)
-        assert d1 is None
-        assert d2 is None
-        assert d3
+        d4 = Document.fetch(4)
+        d5 = Document.fetch(5)
 
-        uris = d3.uris()
-        assert len(uris) == 4
+        assert d1 is None
+        assert d2
+        assert d3 is None
+        assert d4
+        assert d5 is None

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -4,6 +4,7 @@ from nose.tools import *
 from . import TestCase
 from annotator.document import Document
 
+
 class TestDocument(TestCase):
 
     def setup(self):
@@ -16,11 +17,13 @@ class TestDocument(TestCase):
         self.ctx.pop()
         super(TestDocument, self).teardown()
 
-    def test_new(self):
+    @staticmethod
+    def test_new():
         d = Document()
         assert_equal('{}', repr(d))
 
-    def test_basics(self):
+    @staticmethod
+    def test_basics():
         d = Document({
             "id": "1",
             "title": "Annotations: The Missing Manual",
@@ -46,7 +49,8 @@ class TestDocument(TestCase):
         assert d['created']
         assert d['updated']
 
-    def test_delete(self):
+    @staticmethod
+    def test_delete():
         ann = Document(id=1)
         ann.save()
 
@@ -54,9 +58,10 @@ class TestDocument(TestCase):
         newdoc.delete()
 
         nodoc = Document.fetch(1)
-        assert nodoc == None
+        assert nodoc is None
 
-    def test_search(self):
+    @staticmethod
+    def test_search():
         d = Document({
             "id": "1",
             "title": "document",
@@ -75,7 +80,8 @@ class TestDocument(TestCase):
         res = Document.search(query={'title': 'document'})
         assert_equal(len(res), 1)
 
-    def test_get_by_uri(self):
+    @staticmethod
+    def test_get_by_uri():
 
         # create 3 documents and make sure get_by_uri works properly
 
@@ -127,7 +133,8 @@ class TestDocument(TestCase):
         assert doc
         assert_equal(doc['title'], "document1") 
 
-    def test_get_all_by_uri(self):
+    @staticmethod
+    def test_get_all_by_uri():
         # add two documents and make sure we can search for both
 
         d = Document({
@@ -157,7 +164,8 @@ class TestDocument(TestCase):
         docs = Document.get_all_by_uris(["https://peerj.com/articles/53/", "https://peerj.com/articles/53.pdf"])
         assert_equal(len(docs), 2)
 
-    def test_uris(self):
+    @staticmethod
+    def test_uris():
         d = Document({
             "id": "1",
             "title": "document",
@@ -177,7 +185,8 @@ class TestDocument(TestCase):
             "https://peerj.com/articles/53.pdf"
         ])
 
-    def test_merge_links(self):
+    @staticmethod
+    def test_merge_links():
         d = Document({
             "id": "1",
             "title": "document",


### PR DESCRIPTION
This PR offers a fix for the faulty document plugin equivalence mechanism.

**A few words about the old way of working**
Every time an annotation was saved with document metadata we checked if there were any previously existing document which [has the same url.](https://github.com/openannotation/annotator-store/blob/d44c7c028bff9625808e43fabd3487dc6661533a/annotator/annotation.py#L54)
 
If there isn't any, we create a new document with the metadata and [save it](https://github.com/openannotation/annotator-store/blob/d44c7c028bff9625808e43fabd3487dc6661533a/annotator/annotation.py#L57) 
Otherwise, we merge the links into the **first** document (and only the first) and discard the rest of the metadata.

**Changes**
The method used for retrieving documents called [get_all_by_uris()](https://github.com/openannotation/annotator-store/blob/d44c7c028bff9625808e43fabd3487dc6661533a/annotator/document.py#L40) was not helpful for discovering equivalences. For example if `documentA` had `linkA` and `linkB` (meaning that the content on those URI is equivalent) and `documentB` had `linkB` and `linkC`, then if I'd call this `get_all_by_uris()` with the URI `linkA` then it'd only retrieve `documentA` even though here we also need to get `documentB` back too.

So, instead of this, the [get_all_recursive_for_uris()](https://github.com/openannotation/annotator-store/blob/110-multiple-document-equivalences/annotator/document.py#L82) is used which builds a Kleene-star of documents based on the given URIs as seed URIs, with that we have every document we have to work with. (This operation would rarely take long, as this PR offers an aggressive solution to merge equivalent documents into one)

And now saving the document happens inside [save_document_data()](https://github.com/openannotation/annotator-store/blob/110-multiple-document-equivalences/annotator/document.py#L114)

- We collect all possible affected document (via the method detailed above)
- If there are none, we create a new one (as before).
- If there is only one document, we merge the links into it and discard the rest of the data(as before)
- If there is more than one document (this is new), we merge all links into a document and all other links from all retrieved document, and we save this whole document, and delete the rest. This way we'll have only one document containing all links needed. 

The rest of the data is discarded, so as it was before, so that hasn't changed.