### PR TITLE
Sort and order parameters for search queries (Enhance sorting)

### DIFF
--- a/annotator/annotation.py
+++ b/annotator/annotation.py
@@ -102,11 +102,11 @@ class Annotation(es.Model):
         return res
 
     @classmethod
-    def _build_query(cls, query=None, offset=None, limit=None):
+    def _build_query(cls, query=None, offset=None, limit=None, sort=None, order=None):
         if query is None:
             query = {}
 
-        q = super(Annotation, cls)._build_query(query, offset, limit)
+        q = super(Annotation, cls)._build_query(query, offset, limit, sort, order)
 
         # attempt to expand query to include uris for other representations
         # using information we may have on hand about the Document

--- a/annotator/store.py
+++ b/annotator/store.py
@@ -272,6 +272,10 @@ def search_annotations():
         kwargs['offset'] = atoi(params.pop('offset'), default=None)
     if 'limit' in params:
         kwargs['limit'] = atoi(params.pop('limit'), default=None)
+    if 'sort' in params:
+        kwargs['sort'] = params.pop('sort')
+    if 'order' in params:
+        kwargs['order'] = params.pop('order')
 
     # All remaining parameters are considered searched fields.
     kwargs['query'] = params

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -92,11 +92,20 @@ class TestAnnotation(TestCase):
         res = Annotation.search()
         assert_equal(len(res), 3)
 
-        # ordering (most recent first)
+        # ordering (default: most recent first)
         assert_equal(res[0]['text'], uri2)
 
         res = Annotation.count()
         assert_equal(res, 3)
+
+        res = Annotation.search(order='asc')
+        assert_equal(res[0]['text'], uri1)
+
+        res = Annotation.search(sort='user')
+        assert_equal(res[0]['user'], user1)
+
+        res = Annotation.search(sort='user', order='asc')
+        assert_equal(res[0]['user'], user2)
 
         res = Annotation.search(limit=1)
         assert_equal(len(res), 1)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -300,6 +300,30 @@ class TestStore(TestCase):
         assert_equal(res['rows'][0]['uri'], uri1)
         assert_true(res['rows'][0]['id'] in [anno['id'], anno2['id']])
 
+    def test_search_sort_and_order(self):
+        uri1 = u'http://xyz.com'
+        uri2 = u'urn:uuid:xxxxx'
+        user = u'levin'
+        user2 = u'anna'
+        anno = self._create_annotation(uri=uri1, text=uri1, user=user)
+        anno2 = self._create_annotation(uri=uri1, text=uri1 + uri1, user=user2)
+        anno3 = self._create_annotation(uri=uri2, text=uri2, user=user)
+
+        res = self._get_search_results('limit=1&sort=user&order=asc')
+        assert_equal(res['total'], 3)
+        assert_equal(len(res['rows']), 1)
+        assert_equal(res['rows'][0]['user'], user2)
+
+        res = self._get_search_results('limit=1&sort=user&order=desc')
+        assert_equal(res['total'], 3)
+        assert_equal(len(res['rows']), 1)
+        assert_equal(res['rows'][0]['user'], user)
+
+        res = self._get_search_results('limit=1&sort=text&user=' + user)
+        assert_equal(res['total'], 2)
+        assert_equal(len(res['rows']), 1)
+        assert_equal(res['rows'][0]['text'], anno['text'])
+
     def test_search_limit(self):
         for i in xrange(250):
             self._create_annotation(refresh=False)


### PR DESCRIPTION
Similar to offset and limit, now the sort and order
parameters are extracted and used to set sorting field
and order for ES.

Fix #113