### PR TITLE
Ignore 404 on fetch to avoid a log message

### DIFF
--- a/annotator/elasticsearch.py
+++ b/annotator/elasticsearch.py
@@ -131,13 +131,12 @@ class _Model(dict):
     # already define that method name.
     @classmethod
     def fetch(cls, id):
-        try:
-            doc = cls.es.conn.get(index=cls.es.index,
-                                  doc_type=cls.__type__,
-                                  id=id)
-        except elasticsearch.exceptions.NotFoundError:
-            return None
-        return cls(doc['_source'], id=id)
+        doc = cls.es.conn.get(index=cls.es.index,
+                              doc_type=cls.__type__,
+                              ignore=404,
+                              id=id)
+        if doc.get('found', True):
+            return cls(doc['_source'], id=id)
 
     @classmethod
     def _build_query(cls, query=None, offset=None, limit=None, sort=None, order=None):

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -57,9 +57,7 @@ class TestModel(object):
     @patch('annotator.elasticsearch.elasticsearch.Elasticsearch')
     def test_fetch_not_found(self, es_mock):
         conn = es_mock.return_value
-        def raise_exc(*args, **kwargs):
-            raise elasticsearch.exceptions.NotFoundError('foo')
-        conn.get.side_effect = raise_exc
+        conn.get.return_value = {'found': False}
         o = self.Model.fetch(123)
         assert_equal(o, None)
 


### PR DESCRIPTION
Otherwise, elasticsearch will emit a log message even though we
ignore the exception.