### PR TITLE
Do not filter out links without a type

### DIFF
--- a/annotator/document.py
+++ b/annotator/document.py
@@ -69,7 +69,7 @@ class Document(es.Model):
     def merge_links(self, links):
         current_uris = self.uris()
         for l in links:
-            if 'href' in l and 'type' in l and l['href'] not in current_uris:
+            if 'href' in l and l['href'] not in current_uris:
                 self['link'].append(l)
 
     @staticmethod
@@ -114,7 +114,7 @@ class Document(es.Model):
     def _remove_deficient_links(self):
         # Remove links without a type or href
         links = self.get('link', [])
-        filtered_list = [l for l in links if 'type' in l and 'href' in l]
+        filtered_list = [l for l in links if 'href' in l]
         self['link'] = filtered_list
 
     @classmethod

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -76,9 +76,10 @@ class TestDocument(TestCase):
         })
         d.save()
         d = Document.fetch("1")
-        assert_equal(len(d['link']), 1)
+        assert_equal(len(d['link']), 2)
         assert_equal(d['link'][0]['href'], "http://cuckoo.baboon/")
-        assert_equal(d['link'][0]['type'], "text/html")
+        assert_equal(d['link'][1]['href'], "http://cuckoo.baboon/")
+        assert_equal(d['link'][1]['type'], "text/html")
 
     def test_delete(self):
         # Test deleting a document


### PR DESCRIPTION
This is a quick fix for an error I've introduced which can result in searches for uri not bringing back annotations.

**Error description**
- The annotator client saves `document.location.href` into the [document metadata link without a type](https://github.com/openannotation/annotator/blob/v1.2.x/src/plugin/document.coffee#L101)
- When saving the document, we remove [typeless links](https://github.com/openannotation/annotator-store/blob/master/annotator/document.py#L114), therefore removing the saved `document.location.href`
- When we search for annotations and construct the search query, we [rewrite the uri part of the query](https://github.com/openannotation/annotator-store/blob/master/annotator/annotation.py#L105) and [replacing the original uri with the found equivalences](https://github.com/openannotation/annotator-store/blob/master/annotator/annotation.py#L115).

Therefore if  the if we search for an uri of the page and that page doesn't contain a link to itself with a type (common thing among webpages) then the search for that uri will bring back nothing because the document metadata does not contain that uri, and that is not our intention.

Fix #116