### PR TITLE
Copy query object in _build_query()

### DIFF
--- a/annotator/annotation.py
+++ b/annotator/annotation.py
@@ -97,10 +97,11 @@ class Annotation(es.Model):
             query = {}
 
         # Pop 'before' and 'after' parameters out of the query
-        after = query.pop('after', None)
-        before = query.pop('before', None)
+        copied_query = dict(query)
+        after = copied_query.pop('after', None)
+        before = copied_query.pop('before', None)
 
-        q = super(Annotation, cls)._build_query(query, offset, limit, sort, order)
+        q = super(Annotation, cls)._build_query(copied_query, offset, limit, sort, order)
 
         # Create range query from before and/or after
         if before is not None or after is not None:


### PR DESCRIPTION
The before and after parameters are popped out from a copied query,
so the original query dict remains unchanged

Fix #120